### PR TITLE
forward to LOGIN_REDIRECT_URL after successful login on server

### DIFF
--- a/src/django_sso/sso_gateway/views.py
+++ b/src/django_sso/sso_gateway/views.py
@@ -4,6 +4,7 @@ from builtins import super
 from typing import Optional
 
 import django.contrib.auth.views
+from django.conf import settings
 from django.contrib.auth import logout, get_user_model
 from django.http import JsonResponse
 from django.shortcuts import redirect
@@ -40,7 +41,10 @@ class LoginView(django.contrib.auth.views.LoginView):
 			).first()
 
 		if not auth_request or not auth_request.next_url:
-			return reverse_lazy('welcome')
+			if settings.LOGIN_REDIRECT_URL != '/accounts/profile/':
+				return reverse_lazy(settings.LOGIN_REDIRECT_URL)
+			else:
+				return reverse_lazy('welcome')
 
 		try:
 			auth_request.activate(self.request.user)


### PR DESCRIPTION
If `LOGIN_REDIRECT_URL` is set in `settings.py`, then forward to it after a successful login on the server side. Otherwise forward to `welcome`-page
p.s. If `LOGIN_REDIRECT_URL` is not set in `settings.py` it defaults to `/accounts/profile/` (see https://docs.djangoproject.com/en/4.1/topics/auth/default/)