### PR TITLE
Fix: avoid double slash in the login url

### DIFF
--- a/src/django_sso/sso_service/views.py
+++ b/src/django_sso/sso_service/views.py
@@ -40,7 +40,7 @@ def login_view(request):
     return render(
         request,
         context={
-            'redirect_url': f"{settings.SSO['ROOT']}/login/?{params}"
+            'redirect_url': f"{settings.SSO['ROOT'].rstrip('/')}/login/?{params}"
         },
         template_name='django_sso/redirect_to_sso.html'
     )


### PR DESCRIPTION
The redirect-url to the server-login-page contains a double slash: `..//login/..`. Which seems to work locally but is for example a problem when using AWS-Architechture