### PR TITLE
Handle multiple authentication backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ SSO = {
 }
 ```
 
+4) Authentication backend
+
+If you are using multiple authentication backends you need to specify which one should be used by this package. The specified backend must already be listed in ```AUTHENTICATION_BACKENDS```
+
+```python
+SSO = {
+	'AUTHENTICATION_BACKEND': '.....'
+}
+```
 
 
 ## Default behavior summary (In case, when the SSO gateway and subordinated service implemented with the Django SSO)

--- a/src/django_sso/sso_service/apps.py
+++ b/src/django_sso/sso_service/apps.py
@@ -58,4 +58,20 @@ class ServiceConfig(AppConfig):
                     'Can\'t import SSO event acceptor class from SSO[EVENT_ACCEPTOR_CLASS] variable'
                 ))
 
+        if len(settings.AUTHENTICATION_BACKENDS) > 1:
+            auth_backend_class = settings.SSO.get('AUTHENTICATION_BACKEND')
+
+            if auth_backend_class is None:
+                raise ImproperlyConfigured(_(
+                    'You have multiple backends configured in AUTHENTICATION_BACKENDS. You need to defined in SSO(AUTHENTICATION_BACKEND) the class you want to use'
+                ))
+
+            try:
+                next(x for x in settings.AUTHENTICATION_BACKENDS if x == auth_backend_class)
+            except StopIteration:
+                raise ImproperlyConfigured(_(
+                    'You have defined a class in SSO(AUTHENTICATION_BACKEND) that\'s not in AUTHENTICATION_BACKENDS'
+                ))
+
+
         from . import signals

--- a/src/django_sso/sso_service/views.py
+++ b/src/django_sso/sso_service/views.py
@@ -76,7 +76,7 @@ def authorize_from_sso_view(request: WSGIRequest):
 
         set_sso_authorization_request_used(request.session.get('token'))
 
-        login(request, user)
+        login(request, user, backend=settings.SSO.get('AUTHENTICATION_BACKEND'))
 
         if authorization_request['next_url']:
             return redirect(authorization_request['next_url'])


### PR DESCRIPTION
  Some packages require they be added to ```AUTHENTICATION_BACKENDS``` list in ```settings.py``` and as a result the ```login()``` function requires an explicit class name.
 
This code change adds support for ```SSO(AUTHENTICATION_BACKEND``` like this:

```python
SSO = {
'AUTHENTICATION_BACKEND': '....'
}
```